### PR TITLE
Fix Python 3.13 and drop Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=70.2.0", "wheel>=0.44.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tabcompleter"
+readme = "README.md"
+dynamic = [
+    "urls",
+    "version",
+    "license",
+    "authors",
+    "scripts",
+    "keywords",
+    "classifiers",
+    "description",
+    "maintainers",
+    "entry-points",
+    "dependencies",
+    "requires-python",
+    "optional-dependencies",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[flake8]
+ignore = ["W503"]

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if sys.argv[-1] == "publish":
 
 setup(
     name="tabcompleter",
-    version="1.3.3",
+    version="1.4.0",
     description="tabcompleter --- Autocompletion in the Python console.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """*** tabcompleter ***
 Use the TAB key for autocompletion in the Python console.
-(Python 3.7+)"""
+(Python 3.8+)"""
 from setuptools import setup, find_packages  # noqa
 import os
 import sys
@@ -102,7 +102,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -119,7 +118,7 @@ setup(
         "Topic :: Software Development :: Testing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'pyreadline3;platform_system=="Windows"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.argv[-1] == "publish":
             print("\nERROR! Publishing to PyPI requires Python>=3.9")
             sys.exit()
         print("\n*** Checking code health with flake8:\n")
-        os.system("python -m pip install 'flake8==6.1.0'")
+        os.system("python -m pip install 'flake8==7.1.1'")
         flake8_status = os.system("flake8 --exclude=.eggs,temp")
         if flake8_status != 0:
             print("\nERROR! Fix flake8 issues before publishing to PyPI!\n")

--- a/src/tabcompleter.py
+++ b/src/tabcompleter.py
@@ -100,6 +100,7 @@ class DefaultConfig:
             import readline
             import pyreadline  # noqa: F401
             from pyreadline.modes import basemode
+            readline.backend = None
         except ImportError:
             return None
         if hasattr(basemode, "stripcolor"):
@@ -113,6 +114,7 @@ class DefaultConfig:
             if result:
                 return result
         import readline
+        readline.backend = None
         return readline, False
 
     def setup(self):


### PR DESCRIPTION
## Fix Python 3.13 and drop Python 3.7
* [Fix Python 3.13 on Windows](https://github.com/mdmintz/tabcompleter/commit/16ec974781de8a3a1eac2f99fa9d2fd443092065)
* [Drop support for Python 3.7](https://github.com/mdmintz/tabcompleter/commit/ae71b1ae273d1fdb653bbd41ccae71bdabff25e7)
* [Add pyproject.toml](https://github.com/mdmintz/tabcompleter/commit/b01493d50df709abd9a8f9ca00773ae62700f70f)